### PR TITLE
Support for custom Haxe code

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,20 @@
 
 Dragon is a *universal Python translater*. It achieves this by transpiling Python to [Haxe](http://haxe.org), which can then be transpiled and compiled to various platforms and languages (C++, Javascript, Java, C#, Ruby, Python, Lua, etc. for browser/web, desktop, Android, iOS, etc.)
 
+# Usage
+
+- Create some Python code
+- Create a file like `compiler.py`
+- Add the import `from dragon.transpiler.python_to_haxe_transpiler import PythonToHaxeTranspiler`
+- Invoke `PythonToHaxeTranspiler(source_path, files).transpile()` passing in the directory root of the source files (important for package names!) and a list of files to transpile (eg. `os.glob.glob("**/*.py"))`).
+- Check the outputted Haxe code. Invoke the Haxe compiler as usual.
+- Profit
+
+For constructs that don't exist in Python (eg. `override`, `@:...`), add them to your Python code and prefix them with `@haxe:`.
+
+# Caveats
+- When importing Haxe code, use the Haxe-style `from package.subpackage import ClassName`
+
 ----
 
     Currently, Dragon is in a very early stage of development. We're using Lark to generate the parse tree, and then generate the resulting Haxe code. 

--- a/dragon/generators/haxe_generator.py
+++ b/dragon/generators/haxe_generator.py
@@ -1,4 +1,5 @@
 _RAW_HAXE_TOKEN = "@haxe:"
+_GENERATED_OVERRIDE = "override"
 
 def arguments(args):
     return [v for v in args]
@@ -21,7 +22,7 @@ def list_to_newline_separated_text(data, suffix_semicolons=False):
     if suffix_semicolons:
         to_return = []
         for line in data:
-            if "{" not in line and "}" not in line:
+            if "{" not in line and "}" not in line and line != _GENERATED_OVERRIDE:
                 line = "{};".format(line)
             to_return.append(line)
         data = to_return

--- a/dragon/generators/haxe_generator.py
+++ b/dragon/generators/haxe_generator.py
@@ -1,7 +1,4 @@
-_METADATA_START = '"""@'
-_METADATA_END = '"""'
-_OVERRIDE_SYNTAX = '"""#override"""'
-_OVERRIDE_GENERATED = "override"
+_RAW_HAXE_TOKEN = "@haxe:"
 
 def arguments(args):
     return [v for v in args]
@@ -24,7 +21,7 @@ def list_to_newline_separated_text(data, suffix_semicolons=False):
     if suffix_semicolons:
         to_return = []
         for line in data:
-            if "{" not in line and "}" not in line and line != _OVERRIDE_GENERATED:
+            if "{" not in line and "}" not in line:
                 line = "{};".format(line)
             to_return.append(line)
         data = to_return
@@ -56,17 +53,9 @@ def method_call(data):
     return output
 
 def custom_token_or_long_string(data):
-    if data.startswith(_METADATA_START) and data.endswith(_METADATA_END):
-        start = data.index(_METADATA_START) + len(_METADATA_START) - 1
-        stop = data.rindex(_METADATA_END)
-        to_return = data[start:stop]
-        return to_return
-    elif data == _OVERRIDE_SYNTAX:
-        return _OVERRIDE_GENERATED
-    else:
-        # To paraphrase Python's benevolant dictator: these are 
-        # block comments, they don't generate into code!
-        return ""
+    # To paraphrase Python's benevolant dictator: these are 
+    # block comments, they don't generate into code!
+    return ""
 
 def method_declaration(method_name, args, method_body):
     if method_name == "__init__":
@@ -79,6 +68,9 @@ def number(num_string):
         return float(num_string)
     else:
         return int(num_string)
+
+def raw_haxe(haxe_string):
+    return haxe_string.replace(_RAW_HAXE_TOKEN, "").strip()
 
 def value(val):
     return val

--- a/dragon/transpiler/lark/python3.g
+++ b/dragon/transpiler/lark/python3.g
@@ -38,7 +38,7 @@ varargslist: (vfpdef ["=" test] ("," vfpdef ["=" test])* ["," [ "*" [vfpdef] (",
 
 vfpdef: NAME
 
-?stmt: simple_stmt | compound_stmt
+?stmt: simple_stmt | compound_stmt | haxe
 ?simple_stmt: small_stmt (";" small_stmt)* [";"] _NEWLINE
 ?small_stmt: (expr_stmt | del_stmt | pass_stmt | flow_stmt | import_stmt | global_stmt | nonlocal_stmt | assert_stmt)
 ?expr_stmt: testlist_star_expr (annassign | augassign (yield_expr|testlist)
@@ -186,3 +186,5 @@ IMAG_NUMBER.2: /\d+j|${FLOAT_NUMBER}j/i
 _DEDENT: "<DEDENT>"
 _INDENT: "<INDENT>"
 
+// Dragon extension: raw Haxe code. ".+" doesn't work, it captures newlines. [^\n] crashes!
+haxe: /@haxe:\s?([a-zA-Z0-9:"'@, \(\)\.]+)\n*/is

--- a/dragon/transpiler/lark/transformers/haxe_transformer.py
+++ b/dragon/transpiler/lark/transformers/haxe_transformer.py
@@ -101,6 +101,13 @@ class HaxeTransformer(Transformer):
         # methods named __init__ are mapped to new()
         return haxe_generator.method_declaration(method_name, arguments, function_body)
 
+    def haxe(self, data):
+        if isinstance(data, Tree):
+            data = data.value
+        elif isinstance(data, list):
+            data = data[0].value
+        return haxe_generator.raw_haxe(data)
+
     # Import statement, probably of the form: from x.a.b import B
     def import_stmt(self, node):
         node = node[0].children # import_stmt => import_from

--- a/tests/generators/test_haxe_generator.py
+++ b/tests/generators/test_haxe_generator.py
@@ -46,6 +46,11 @@ class TestHaxeGenerator(unittest.TestCase):
         self.assertEqual("first line;\nsecond line;\nthird line!;", output)
         self.assertEqual(len(data), output.count(";"))
 
+    def test_list_to_newline_excludes_override_statements(self):
+        data = ["class X extends FlxState", "override", "public function create()"]
+        output = haxe_generator.list_to_newline_separated_text(data, suffix_semicolons=True)
+        self.assertEqual("class X extends FlxState;\noverride\npublic function create();", output)
+
     def test_custom_token_or_long_string_turns_long_string_into_empty_string(self):
         data = '"""Here is a nice doc-string comment!"""'
         output = haxe_generator.custom_token_or_long_string(data)

--- a/tests/generators/test_haxe_generator.py
+++ b/tests/generators/test_haxe_generator.py
@@ -46,12 +46,6 @@ class TestHaxeGenerator(unittest.TestCase):
         self.assertEqual("first line;\nsecond line;\nthird line!;", output)
         self.assertEqual(len(data), output.count(";"))
 
-    def test_custom_token_or_long_string_turns_metadata_string_into_metadata(self):
-        metadata = '@:build(flixel.system.FlxAssets.buildFileReferences("assets", true))'
-        data = '"""{}"""'.format(metadata)
-        output = haxe_generator.custom_token_or_long_string(data)
-        self.assertIn(metadata, output)
-
     def test_custom_token_or_long_string_turns_long_string_into_empty_string(self):
         data = '"""Here is a nice doc-string comment!"""'
         output = haxe_generator.custom_token_or_long_string(data)
@@ -81,7 +75,6 @@ class TestHaxeGenerator(unittest.TestCase):
             "is_constructor": True})
 
         self.assertEqual('new Monster("assets/images/duck.png", 5, 1)', output)
-    
     
     @parameterized.expand([
         ['super()'],
@@ -125,6 +118,11 @@ class TestHaxeGenerator(unittest.TestCase):
         for num in (0, 9999, -19232):
             output = haxe_generator.number("{}".format(num))
             self.assertEqual(num, output)
+
+    def test_raw_haxe_extracts_haxe_code(self):
+        haxe_code = "a.b(c, d)"
+        output= haxe_generator.raw_haxe("@haxe: {}".format(haxe_code))
+        self.assertEqual(haxe_code, output)
 
     def test_value_returns_variable_name(self):
         variable_names = ["Sprite", "some_variable", "out_of_100_monkeys"]

--- a/tests/transpiler/lark/transformers/test_haxe_transformer.py
+++ b/tests/transpiler/lark/transformers/test_haxe_transformer.py
@@ -94,6 +94,29 @@ class TestHaxeTransformer(unittest.TestCase):
         self.assertIn("function new()", output)
         self.assertIn("addChild", output)
 
+    def test_haxe_turns_list_into_haxe_code(self):
+        h = HaxeTransformer()
+        haxe_code = '@:build(flixel.system.FlxAssets.buildFileReferences("assets", true))'
+        metadata = '@haxe: {}'.format(haxe_code)
+        data = [Token("LONG_STRING", metadata)]
+        output = h.haxe(data)
+        self.assertEqual(haxe_code, output)
+
+    def test_haxe_turns_node_into_haxe_code(self):
+        h = HaxeTransformer()
+        haxe_code = '@:build(flixel.system.FlxAssets.buildFileReferences("assets", true))'
+        metadata = '@haxe: {}'.format(haxe_code)
+        data = Token("LONG_STRING",metadata)
+        output = h.haxe(data)
+        self.assertEqual(haxe_code, output)
+
+    def test_haxe_turns_string_into_haxe_code(self):
+        h = HaxeTransformer()
+        haxe_code = '@:build(flixel.system.FlxAssets.buildFileReferences("assets", true))'
+        data = '@haxe: {}'.format(haxe_code)
+        output = h.haxe(data)
+        self.assertEqual(haxe_code, output)
+
     def test_import_stmt_transforms_simple_imports(self):
         h = HaxeTransformer()
 
@@ -142,25 +165,25 @@ class TestHaxeTransformer(unittest.TestCase):
         output = h.parameters(data)
         self.assertEqual(output, ["elapsed", "mode"])
 
-    def test_string_turns_list_into_metadata(self):
+    def test_string_turns_list_into_empty_string(self):
         h = HaxeTransformer()
         metadata = '@:build(flixel.system.FlxAssets.buildFileReferences("assets", true))'
         data = [Token("LONG_STRING", '"""{}"""'.format(metadata))]
         output = h.string(data)
-        self.assertEqual(metadata, output)
+        self.assertEqual("", output)
 
-    def test_string_turns_node_into_metadata(self):
+    def test_string_turns_node_into_empty_string(self):
         h = HaxeTransformer()
         metadata = '@:build(flixel.system.FlxAssets.buildFileReferences("assets", true))'
         data = Token("LONG_STRING", '"""{}"""'.format(metadata))
         output = h.string(data)
-        self.assertEqual(metadata, output)
+        self.assertEqual("", output)
 
-    def test_string_turns_string_into_metadata(self):
+    def test_string_turns_string_into_empty_string(self):
         h = HaxeTransformer()
         data = '@:build(flixel.system.FlxAssets.buildFileReferences("assets", true))'
         output = h.string(data)
-        self.assertIn(output, data)
+        self.assertIn("", data)
 
     def test_suite_returns_newline_separated_text_with_semicolons(self):
         h = HaxeTransformer()


### PR DESCRIPTION
Implemented new `@haxe: ...` statement that transforms as raw Haxe code (instead of multiple ways to declare metadata, override methods, etc.)